### PR TITLE
Deprecate old method to get server supported features.

### DIFF
--- a/OCCommunicationLib/OCCommunicationLib/OCCommunication.h
+++ b/OCCommunicationLib/OCCommunicationLib/OCCommunication.h
@@ -24,6 +24,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "OCServerFeatures.h"
 
 @class OCHTTPRequestOperation;
 @class AFURLSessionManager;
@@ -511,6 +512,8 @@ typedef enum {
 ///-----------------------------------
 
 /**
+ * DEPRECATED use + getFeaturesSupportedByServerForVersion: instead
+ *
  * Method get the features supported by the path server using the version string.
  *
  * Right now support:
@@ -519,6 +522,7 @@ typedef enum {
  * - Cookies
  * - Forbidden character manage by the server side
  * - Capabilities
+ * - Federated Shares has Option of Share
  *
  * @param path -> NSString server path
  * @param sharedOCCommunication -> OCCommunication Singleton of communication to add the operation on the queue.
@@ -530,8 +534,30 @@ typedef enum {
 
 - (void) getFeaturesSupportedByServer:(NSString*) path onCommunication:(OCCommunication *)sharedOCCommunication
                        successRequest:(void(^)(NSHTTPURLResponse *response, BOOL hasShareSupport, BOOL hasShareeSupport, BOOL hasCookiesSupport, BOOL hasForbiddenCharactersSupport, BOOL hasCapabilitiesSupport, BOOL hasFedSharesOptionShareSupport, NSString *redirectedServer)) success
-                       failureRequest:(void(^)(NSHTTPURLResponse *response, NSError *error, NSString *redirectedServer)) failure;
+                       failureRequest:(void(^)(NSHTTPURLResponse *response, NSError *error, NSString *redirectedServer)) failure __deprecated_msg("Use + getFeaturesSupportedByServerForVersion: instead");
 
+
+///-----------------------------------
+/// @name Get Features Supported By Server
+///-----------------------------------
+
+/**
+ * Method get the features supported by server for version.
+ *
+ * Right now support:
+ * - Share API
+ * - Sharee API
+ * - Cookies
+ * - Forbidden character manage by the server side
+ * - Capabilities
+ * - Federated Shares has Option of Share
+ *
+ * @param version -> NSString server version
+ *
+ * @return OCServerFeatures obj
+ *
+ */
+- (OCServerFeatures *) getFeaturesSupportedByServerForVersion:(NSString *)version;
 
 
 ///-----------------------------------

--- a/OCCommunicationLib/OCCommunicationLib/OCCommunication.m
+++ b/OCCommunicationLib/OCCommunicationLib/OCCommunication.m
@@ -37,6 +37,7 @@
 #import "AFURLSessionManager.h"
 #import "OCShareUser.h"
 #import "OCCapabilities.h"
+#import "OCServerFeatures.h"
 
 @interface OCCommunication ()
 
@@ -203,7 +204,7 @@
                 break;
             }
             case credentialCookie:
-                NSLog(@"Cookie: %@", self.password);
+                //NSLog(@"Cookie: %@", self.password);
                 [myRequest addValue:self.password forHTTPHeaderField:@"Cookie"];
                 break;
             case credentialOauth:
@@ -708,11 +709,21 @@
         failure(response, error, request.redirectedServer);
     }];
 
-    
-    
-    
 }
 
+- (OCServerFeatures *) getFeaturesSupportedByServerForVersion:(NSString *)version {
+    
+    BOOL hasShareSupport = [UtilsFramework isServerVersion:version higherThanLimitVersion:k_version_support_shared];
+    BOOL hasShareeSupport = [UtilsFramework isServerVersion:version higherThanLimitVersion:k_version_support_sharee_api];
+    BOOL hasCookiesSupport = [UtilsFramework isServerVersion:version higherThanLimitVersion:k_version_support_cookies];
+    BOOL hasForbiddenCharactersSupport = [UtilsFramework isServerVersion:version higherThanLimitVersion:k_version_support_forbidden_characters];
+    BOOL hasCapabilitiesSupport = [UtilsFramework isServerVersion:version higherThanLimitVersion:k_version_support_capabilities];
+    BOOL hasFedSharesOptionShareSupport = [UtilsFramework isServerVersion:version higherThanLimitVersion:k_version_support_share_option_fed_share];
+    
+    OCServerFeatures *supportedFeatures = [[OCServerFeatures alloc] initWithSupportForShare:hasShareSupport sharee:hasShareeSupport cookies:hasCookiesSupport forbiddenCharacters:hasForbiddenCharactersSupport capabilities:hasCapabilitiesSupport fedSharesOptionShare:hasFedSharesOptionShareSupport];
+    
+    return supportedFeatures;
+}
 
 - (void) readSharedByServer: (NSString *) path
             onCommunication:(OCCommunication *)sharedOCCommunication
@@ -1146,7 +1157,7 @@
         //Parse
         NSError *error;
         NSDictionary *jsongParsed = [NSJSONSerialization JSONObjectWithData:responseData options:NSJSONReadingMutableContainers error:&error];
-        NSLog(@"dic: %@",jsongParsed);
+        //NSLog(@"dic: %@",jsongParsed);
         
         OCCapabilities *capabilities = [OCCapabilities new];
         

--- a/OCCommunicationLib/OCCommunicationLib/OCServerFeatures.h
+++ b/OCCommunicationLib/OCCommunicationLib/OCServerFeatures.h
@@ -1,0 +1,20 @@
+//
+//  OCServerFeatures.h
+//  ownCloud iOS library
+//
+//  Created by Noelia Alvarez on 05/04/17.
+//  Copyright © 2017 ownCloud. All rights reserved.
+//
+
+@interface OCServerFeatures : NSObject
+
+@property BOOL hasShareSupport;
+@property BOOL hasShareeSupport;
+@property BOOL hasCookiesSupport;
+@property BOOL hasForbiddenCharactersSupport;
+@property BOOL hasCapabilitiesSupport;
+@property BOOL hasFedSharesOptionShareSupport;
+
+- (id)initWithSupportForShare:(BOOL)share sharee:(BOOL)sharee cookies:(BOOL)cookies forbiddenCharacters:(BOOL)forbiddenCharacters capabilities:(BOOL)capabilites fedSharesOptionShare:(BOOL)fedSharesOptionShare;
+
+@end

--- a/OCCommunicationLib/OCCommunicationLib/OCServerFeatures.m
+++ b/OCCommunicationLib/OCCommunicationLib/OCServerFeatures.m
@@ -1,0 +1,28 @@
+//
+//  OCServerFeatures.m
+//  ownCloud iOS library
+//
+//  Created by Noelia Alvarez on 05/04/17.
+//  Copyright © 2017 ownCloud. All rights reserved.
+//
+
+#import "OCServerFeatures.h"
+
+@implementation OCServerFeatures
+
+- (id)initWithSupportForShare:(BOOL)share sharee:(BOOL)sharee cookies:(BOOL)cookies forbiddenCharacters:(BOOL)forbiddenCharacters capabilities:(BOOL)capabilites fedSharesOptionShare:(BOOL)fedSharesOptionShare {
+    
+    self = [super init];
+    if (self) {
+        // Custom initialization
+        _hasShareSupport = share;
+        _hasShareeSupport = sharee;
+        _hasCookiesSupport = cookies;
+        _hasForbiddenCharactersSupport = forbiddenCharacters;
+        _hasCapabilitiesSupport = capabilites;
+        _hasFedSharesOptionShareSupport = fedSharesOptionShare;
+    }
+    
+    return self;
+}
+@end

--- a/OCCommunicationLib/ownCloud iOS library.xcodeproj/project.pbxproj
+++ b/OCCommunicationLib/ownCloud iOS library.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		1345E4601884213400153F14 /* OCXMLShareByLinkParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 1345E45F1884213400153F14 /* OCXMLShareByLinkParser.m */; };
 		13AA8636187C211900A10927 /* OCSharedDto.m in Sources */ = {isa = PBXBuildFile; fileRef = 13AA8635187C211900A10927 /* OCSharedDto.m */; };
 		13AA8640187C3B9700A10927 /* OCXMLParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 13AA863F187C3B9700A10927 /* OCXMLParser.m */; };
+		40D4039D1E955C020003A855 /* OCServerFeatures.m in Sources */ = {isa = PBXBuildFile; fileRef = 40D4039C1E955C020003A855 /* OCServerFeatures.m */; };
 		59A5B71E191907F100724BE3 /* AFHTTPSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 59A5B70E191907F100724BE3 /* AFHTTPSessionManager.m */; };
 		59A5B71F191907F100724BE3 /* AFNetworkReachabilityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 59A5B711191907F100724BE3 /* AFNetworkReachabilityManager.m */; };
 		59A5B720191907F100724BE3 /* AFSecurityPolicy.m in Sources */ = {isa = PBXBuildFile; fileRef = 59A5B713191907F100724BE3 /* AFSecurityPolicy.m */; };
@@ -81,6 +82,8 @@
 		13AA8635187C211900A10927 /* OCSharedDto.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = OCSharedDto.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		13AA863E187C3B9700A10927 /* OCXMLParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; name = OCXMLParser.h; path = OCWebDavClient/Parsers/OCXMLParser.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		13AA863F187C3B9700A10927 /* OCXMLParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = OCXMLParser.m; path = OCWebDavClient/Parsers/OCXMLParser.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		40D4039B1E955C020003A855 /* OCServerFeatures.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OCServerFeatures.h; sourceTree = "<group>"; };
+		40D4039C1E955C020003A855 /* OCServerFeatures.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OCServerFeatures.m; sourceTree = "<group>"; };
 		591BFBF31B1C809000AB8D3A /* OCConstants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = OCConstants.h; path = Utils/OCConstants.h; sourceTree = "<group>"; };
 		59A3EBC718FBD4E700D31D1B /* ConfigTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConfigTests.h; sourceTree = "<group>"; };
 		59A5B70D191907F100724BE3 /* AFHTTPSessionManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AFHTTPSessionManager.h; path = ExternalLibs/AFNetworking/AFHTTPSessionManager.h; sourceTree = "<group>"; };
@@ -215,6 +218,8 @@
 				EA0599991BB96D14002C2864 /* OCShareUser.m */,
 				13AA8634187C211900A10927 /* OCSharedDto.h */,
 				13AA8635187C211900A10927 /* OCSharedDto.m */,
+				40D4039B1E955C020003A855 /* OCServerFeatures.h */,
+				40D4039C1E955C020003A855 /* OCServerFeatures.m */,
 				EA913A701BE9FB0700D015B8 /* OCCapabilities.h */,
 				EA913A711BE9FB0700D015B8 /* OCCapabilities.m */,
 				EAABAA2F183E687000909831 /* OCFrameworkConstants.h */,
@@ -432,6 +437,7 @@
 				EA7CC912183E146000B6A4B4 /* UtilsFramework.m in Sources */,
 				EA7CC92A183E14A100B6A4B4 /* NSDate+RFC1123.m in Sources */,
 				13AA8636187C211900A10927 /* OCSharedDto.m in Sources */,
+				40D4039D1E955C020003A855 /* OCServerFeatures.m in Sources */,
 				EA7CC928183E14A100B6A4B4 /* NSDate+ISO8601.m in Sources */,
 				EAABAB2618585C5200909831 /* NSString+Encode.m in Sources */,
 				59A5B722191907F100724BE3 /* AFURLRequestSerialization.m in Sources */,


### PR DESCRIPTION
 Advise with a warning at compile time. Create new method to get an object with all the server supported features