### PR TITLE
Fix crash due empty responseData

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ osx_image: xcode8.3
 script:
 - set -o pipefail && xcodebuild -project 'OCCommunicationLib/ownCloud iOS library.xcodeproj' -scheme 'ownCloud iOS library' -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 7,OS=10.0' clean test build | xcpretty -c
 #- xctool test -project 'OCCommunicationLib/ownCloud iOS library.xcodeproj' -scheme 'ownCloud iOS library' -sdk iphonesimulator -UseSanitizedBuildSystemEnvironment=YES
-
+ 
 before_install:
 - brew update; brew update
 - echo "#define k_base_url @\"$baseUrlTravis\"" > OCCommunicationLib/OCCommunicationLibTests/ConfigTests.h

--- a/Doc_Changelog.md
+++ b/Doc_Changelog.md
@@ -1,4 +1,7 @@
-## What's new in 2.2.0 version
+## What's new in 2.2.1 version
+- Bug fixed possible crash
+
+## 2.2.0 version
 - Added OAuth2 support with automatic refresh of new tokens
 - Added support to new public share link option that allows you to share a folder with only the option of uploading files to it
 - Added methods to get user data and features supported by server

--- a/OCCommunicationLib/OCCommunicationLib/OCCommunication.m
+++ b/OCCommunicationLib/OCCommunicationLib/OCCommunication.m
@@ -152,7 +152,6 @@
 #pragma mark - Setting Credentials
 
 - (void) setCredentials:(OCCredentialsDto *) credentials {
-    
     self.credDto = credentials;
 }
 
@@ -1536,8 +1535,9 @@
 
 - (void) returnErrorWithResponse:(NSHTTPURLResponse *) response andResponseData:(NSData *) responseData andError:(NSError *) error failureRequest:(void (^)(NSHTTPURLResponse *response, NSError *error, NSString *redirectedServer))failureRequest andRequest:(OCWebDAVClient *) request {
     OCXMLServerErrorsParser *serverErrorParser = [OCXMLServerErrorsParser new];
-       
-    [serverErrorParser startToParseWithData:responseData withCompleteBlock:^(NSError *err) {
+    
+    if (responseData != nil) {
+      [serverErrorParser startToParseWithData:responseData withCompleteBlock:^(NSError *err) {
         
         if (err) {
             failureRequest(response, err, request.redirectedServer);
@@ -1545,7 +1545,10 @@
             failureRequest(response, error, request.redirectedServer);
         }
         
-    }];
+      }];
+    } else {
+      failureRequest(response, error, request.redirectedServer);
+    }
 }
 
 @end

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ownCloud iOS Library v 2.2.0
+# ownCloud iOS Library v 2.2.1
 
 ### Introduction
 Using ownCloud iOS library it will be the easiest way to communicate with ownCloud servers.
@@ -116,6 +116,6 @@ ownCloud iOS library uses some classes based in  https://github.com/zwaldowski/D
 
 ### Compatibility
 
-ownCloud iOS library supports iOS 9 and iOS10 and works in Xcode 8.
+ownCloud iOS library supports iOS 9, iOS10, iOS11 and works in Xcode 8 and Xcode 9.
 
 ownCloud iOS library supports ownCloud server from version 4.5.


### PR DESCRIPTION
Fix crash due empty responseData, 
Increment version number for new release 2.2.1 included within release of iOS OC app 3.7.2.
